### PR TITLE
feat: Add Top Individual and Team Rankings section to admin dashboard

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -881,6 +881,38 @@
             </div>
         </div>
 
+        <!-- Rankings Section -->
+        <div class="section-header">
+            <h2>🏆 Top Individual and Team Rankings</h2>
+            <p>Current leaderboards and performance analytics</p>
+        </div>
+        
+        <div class="dashboard-section">
+            <!-- Overall Top Individual for the Week -->
+            <div class="card overview-card">
+                <h2>👑 Overall Top Individual (Weekly)</h2>
+                <p>The highest performing individual across all teams this week</p>
+                <div style="margin-bottom: 16px;">
+                    <button class="btn btn-secondary" onclick="refreshRankings()">🔄 Refresh Rankings</button>
+                </div>
+                <div id="topIndividualWeekly">Loading top performer...</div>
+            </div>
+
+            <!-- Top Individual Rankings -->
+            <div class="card overview-card">
+                <h2>🥇 Top Individual Rankings</h2>
+                <p>Leading individuals by total steps</p>
+                <div id="topIndividualsRanking">Loading individual rankings...</div>
+            </div>
+
+            <!-- Team Rankings -->
+            <div class="card overview-card">
+                <h2>🏅 Team Rankings</h2>
+                <p>Team performance by average steps per member</p>
+                <div id="teamRankings">Loading team rankings...</div>
+            </div>
+        </div>
+
         <!-- Developer Tools Section -->
         <div class="section-header">
             <h2>🧪 Developer & Debug Tools</h2>
@@ -996,6 +1028,7 @@
                 
                 await this.loadStatistics();
                 await this.loadUsers();
+                await this.loadRankings();
                 await this.loadSystemDiagnostics();
                 this.setupEventListeners();
             }
@@ -1050,6 +1083,206 @@
                     document.getElementById('totalSteps').textContent = 'Error';
                     document.getElementById('avgSteps').textContent = 'Error';
                 }
+            }
+
+            async loadRankings() {
+                try {
+                    console.log('🏆 Loading rankings data...');
+                    
+                    // Check if SupabaseHelper is available
+                    if (typeof SupabaseHelper === 'undefined') {
+                        throw new Error('SupabaseHelper not loaded');
+                    }
+                    
+                    const [users, teamStats] = await Promise.all([
+                        SupabaseHelper.getAllUsers(),
+                        SupabaseHelper.getTeamStats()
+                    ]);
+                    
+                    this.displayTopIndividualWeekly(users);
+                    this.displayTopIndividualsRanking(users);
+                    this.displayTeamRankings(teamStats);
+                    
+                    console.log('✅ Rankings loaded successfully');
+                } catch (error) {
+                    console.error('❌ Error loading rankings:', error);
+                    
+                    // Show error in UI
+                    document.getElementById('topIndividualWeekly').innerHTML = `
+                        <div style="color: #dc2626; padding: 10px; background: #fee2e2; border-radius: 6px;">
+                            Error loading top individual: ${error.message}
+                        </div>
+                    `;
+                    document.getElementById('topIndividualsRanking').innerHTML = `
+                        <div style="color: #dc2626; padding: 10px; background: #fee2e2; border-radius: 6px;">
+                            Error loading individual rankings: ${error.message}
+                        </div>
+                    `;
+                    document.getElementById('teamRankings').innerHTML = `
+                        <div style="color: #dc2626; padding: 10px; background: #fee2e2; border-radius: 6px;">
+                            Error loading team rankings: ${error.message}
+                        </div>
+                    `;
+                }
+            }
+
+            displayTopIndividualWeekly(users) {
+                const container = document.getElementById('topIndividualWeekly');
+                
+                if (!users || users.length === 0) {
+                    container.innerHTML = `
+                        <div style="text-align: center; color: #6b7280; padding: 20px;">
+                            No user data available
+                        </div>
+                    `;
+                    return;
+                }
+                
+                // Get the top performer (users are already sorted by total_steps desc)
+                const topPerformer = users[0];
+                const totalSteps = topPerformer.total_steps || 0;
+                
+                container.innerHTML = `
+                    <div style="background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); border: 2px solid #f59e0b; border-radius: 12px; padding: 24px; text-align: center;">
+                        <div style="display: flex; align-items: center; justify-content: center; gap: 16px; margin-bottom: 16px;">
+                            <div style="font-size: 48px;">👑</div>
+                            <div>
+                                <div style="font-size: 24px; font-weight: 800; color: #92400e; margin-bottom: 4px;">
+                                    ${topPerformer.name}
+                                </div>
+                                <div style="font-size: 16px; color: #b45309; font-weight: 600;">
+                                    ${topPerformer.team}
+                                </div>
+                            </div>
+                        </div>
+                        <div style="font-size: 32px; font-weight: 800; color: #92400e; margin-bottom: 8px;">
+                            ${totalSteps.toLocaleString()}
+                        </div>
+                        <div style="font-size: 14px; color: #b45309; font-weight: 600;">
+                            TOTAL STEPS THIS WEEK
+                        </div>
+                        ${totalSteps >= 50000 ? `
+                            <div style="margin-top: 12px; padding: 8px 16px; background: rgba(34, 197, 94, 0.2); border-radius: 8px; color: #166534; font-weight: 600; font-size: 14px;">
+                                🎉 Incredible Achievement! 
+                            </div>
+                        ` : totalSteps >= 30000 ? `
+                            <div style="margin-top: 12px; padding: 8px 16px; background: rgba(59, 130, 246, 0.2); border-radius: 8px; color: #1d4ed8; font-weight: 600; font-size: 14px;">
+                                🌟 Outstanding Performance!
+                            </div>
+                        ` : ''}
+                    </div>
+                `;
+            }
+
+            displayTopIndividualsRanking(users) {
+                const container = document.getElementById('topIndividualsRanking');
+                
+                if (!users || users.length === 0) {
+                    container.innerHTML = `
+                        <div style="text-align: center; color: #6b7280; padding: 20px;">
+                            No user data available
+                        </div>
+                    `;
+                    return;
+                }
+                
+                // Take top 10 users
+                const top10 = users.slice(0, 10);
+                
+                let html = '<div style="display: grid; gap: 8px;">';
+                
+                top10.forEach((user, index) => {
+                    const rank = index + 1;
+                    const steps = user.total_steps || 0;
+                    
+                    // Medal icons for top 3
+                    let rankIcon = `<span style="font-weight: 700; color: #6b7280;">${rank}</span>`;
+                    if (rank === 1) rankIcon = '🥇';
+                    else if (rank === 2) rankIcon = '🥈';
+                    else if (rank === 3) rankIcon = '🥉';
+                    
+                    const bgColor = rank <= 3 ? 'linear-gradient(135deg, #fef3c7 0%, #fde68a 100%)' : '#f8fafc';
+                    const borderColor = rank <= 3 ? '#f59e0b' : '#e2e8f0';
+                    
+                    html += `
+                        <div style="display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; background: ${bgColor}; border: 1px solid ${borderColor}; border-radius: 8px;">
+                            <div style="display: flex; align-items: center; gap: 12px;">
+                                <div style="font-size: 18px; min-width: 24px; text-align: center;">
+                                    ${rankIcon}
+                                </div>
+                                <div>
+                                    <div style="font-weight: 600; color: #1f2937;">${user.name}</div>
+                                    <div style="font-size: 12px; color: #6b7280;">${user.team}</div>
+                                </div>
+                            </div>
+                            <div style="text-align: right;">
+                                <div style="font-weight: 700; color: #1f2937;">${steps.toLocaleString()}</div>
+                                <div style="font-size: 12px; color: #6b7280;">steps</div>
+                            </div>
+                        </div>
+                    `;
+                });
+                
+                html += '</div>';
+                container.innerHTML = html;
+            }
+
+            displayTeamRankings(teamStats) {
+                const container = document.getElementById('teamRankings');
+                
+                if (!teamStats || teamStats.length === 0) {
+                    container.innerHTML = `
+                        <div style="text-align: center; color: #6b7280; padding: 20px;">
+                            No team data available
+                        </div>
+                    `;
+                    return;
+                }
+                
+                // Sort teams by average steps per member
+                const sortedTeams = teamStats.sort((a, b) => {
+                    const avgA = a.member_count > 0 ? a.total_steps / a.member_count : 0;
+                    const avgB = b.member_count > 0 ? b.total_steps / b.member_count : 0;
+                    return avgB - avgA;
+                });
+                
+                let html = '<div style="display: grid; gap: 8px;">';
+                
+                sortedTeams.forEach((team, index) => {
+                    const rank = index + 1;
+                    const avgSteps = team.member_count > 0 ? Math.round(team.total_steps / team.member_count) : 0;
+                    
+                    // Medal icons for top 3
+                    let rankIcon = `<span style="font-weight: 700; color: #6b7280;">${rank}</span>`;
+                    if (rank === 1) rankIcon = '🥇';
+                    else if (rank === 2) rankIcon = '🥈';
+                    else if (rank === 3) rankIcon = '🥉';
+                    
+                    const bgColor = rank <= 3 ? 'linear-gradient(135deg, #e0f2fe 0%, #b3e5fc 100%)' : '#f8fafc';
+                    const borderColor = rank <= 3 ? '#0288d1' : '#e2e8f0';
+                    
+                    html += `
+                        <div style="display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; background: ${bgColor}; border: 1px solid ${borderColor}; border-radius: 8px;">
+                            <div style="display: flex; align-items: center; gap: 12px;">
+                                <div style="font-size: 18px; min-width: 24px; text-align: center;">
+                                    ${rankIcon}
+                                </div>
+                                <div>
+                                    <div style="font-weight: 600; color: #1f2937;">${team.team}</div>
+                                    <div style="font-size: 12px; color: #6b7280;">${team.member_count} members</div>
+                                </div>
+                            </div>
+                            <div style="text-align: right;">
+                                <div style="font-weight: 700; color: #1f2937;">${avgSteps.toLocaleString()}</div>
+                                <div style="font-size: 12px; color: #6b7280;">avg steps</div>
+                                <div style="font-size: 11px; color: #9ca3af;">${team.total_steps.toLocaleString()} total</div>
+                            </div>
+                        </div>
+                    `;
+                });
+                
+                html += '</div>';
+                container.innerHTML = html;
             }
 
             async loadUsers(bustCache = false) {
@@ -1500,9 +1733,21 @@
                 dashboard.loadStatistics();
                 console.log('👥 Refreshing users with cache busting...');
                 dashboard.loadUsers(true); // Always use cache busting for refresh
+                console.log('🏆 Refreshing rankings...');
+                dashboard.loadRankings();
                 console.log('✅ Data refresh initiated');
             } else {
                 console.error('❌ Dashboard not available for refresh');
+            }
+        }
+
+        function refreshRankings() {
+            console.log('🏆 refreshRankings() called, dashboard available:', !!dashboard);
+            if (dashboard) {
+                console.log('🏆 Refreshing rankings data...');
+                dashboard.loadRankings();
+            } else {
+                console.error('❌ Dashboard not available for rankings refresh');
             }
         }
 


### PR DESCRIPTION
- Add new 'Top Individual and Team Rankings' section below Content Management
- Display overall top individual (weekly) with special golden design and achievement badges
- Show top 10 individual rankings with medal icons for top 3 performers
- Display team rankings sorted by average steps per member for fairness
- Include manual refresh functionality for rankings data
- Integrate with existing SupabaseHelper APIs (getAllUsers, getTeamStats)
- Add error handling and responsive design matching dashboard aesthetics
- Rankings load automatically on dashboard initialization and can be refreshed independently

This enhancement provides administrators with better visibility into participant performance and team competition dynamics during the CxE Americas Offsite 2025 step tracking challenge.